### PR TITLE
fix: only add accordion toggle trigger if in subTables

### DIFF
--- a/src/Resources/views/tailwind_2/_table.html.twig
+++ b/src/Resources/views/tailwind_2/_table.html.twig
@@ -159,11 +159,12 @@
             </tr>
         {% endif %}
         {% for row in table.rows %}
+            {% set subTables = table.getSubTables(row) %}
+            {% set subTableStimulusAction = subTables ? stimulus_action('araise/table-bundle/accordion', 'toggle', 'click') : '' %}
             <tr class="whatwedo_table-row hover:bg-neutral-100 transition duration-500 color align-top"
-                {{ stimulus_action('araise/table-bundle/accordion', 'toggle', 'click') }}
+                {{ subTableStimulusAction }}
                 aria-expanded="false"
             >
-                {% set subTables = table.getSubTables(row) %}
                 {% if table.hasBatchActions() and table.getOption('content_visibility')['content_show_header'] %}
                     <td class="px-6 py-2">
                         <input


### PR DESCRIPTION
I always got the following error in the console.
```
Error invoking action "click->araise--table-bundle--accordion#toggle"

TypeError: Cannot read properties of null (reading 'classList')
    at extended.toggle (accordion_controller.js:21:1)
    at Binding.invokeWithEvent (stimulus.js:278:1)
    at Binding.handleEvent (stimulus.js:260:1)
    at EventListener.handleEvent (stimulus.js:31:1)
```

So I poked around and found out that we only use the accordion if there is a sub-table. But we set the trigger regardless. This fix only sets the trigger if there actually are sub-tables that can be opened by the accordion.