### PR TITLE
feat: add OPT_VISIBILITY for TableActions

### DIFF
--- a/docs/table-configuration.md
+++ b/docs/table-configuration.md
@@ -27,18 +27,14 @@ All Options are as constants in `Table` class.
 
 Example
 ```php
-public function configureTable(Table $table): void
-    {
-        parent::configureTable($table);
-        $table
-            ->addColumn('firstname')
-            ->addColumn('lastname')
-            ->addColumn('birthday', null, [
-                'sortable' => false,
-                'formatter' => UserBirthdayFormatter::class,
-            ])
-        ;
-    }
+$table
+    ->addColumn('firstname')
+    ->addColumn('lastname')
+    ->addColumn('birthday', null, [
+        'sortable' => false,
+        'formatter' => UserBirthdayFormatter::class,
+    ])
+;
 ```
 
 For the columns you have a few options to tweak how they behave:
@@ -56,13 +52,38 @@ All Options are as constants in `Column` class.
 Action Columns are here to link to other pages (f.ex. link to edit or view).
 This column has a special template to render the links.
 
-### Options
+### Add A Table Action
+You can add your own table actions like this:
+```php
+$table->addAction('test', [
+    Action::OPT_LABEL => 'Test Button',
+    Action::OPT_ROUTE => self::getRoute(Page::SHOW),
+    Action::OPT_ROUTE_PARAMETERS => fn ($row) => [
+        'id' => $row->getId(),
+    ],
+]);
+```
+As per default, the `addAction()`-method will use the `Action` class for your configuration.
 
-- `items`: Array of columns. Every item has this options:
-- `label`: Name of the button
-- `icon`: Icon (in our templates, we're using Font Awesome 4)
-- `button`: Type of button (f.ex. primary, we're using Bootstrap Button's in our base template)
-- `route`: Route to call. Parameter `id` is always given
+To change which rows can use an action, try using the `TableAction` class and its `visibility` option instead:
+```php
+$table->addAction('test', [
+    Action::OPT_LABEL => 'Test Button',
+    Action::OPT_ROUTE => self::getRoute(Page::SHOW),
+    Action::OPT_ROUTE_PARAMETERS => fn ($row) => [
+        'id' => $row->getId(),
+    ],
+    TableAction::OPT_VISIBILITY => fn($row) => $row->getId() % 2 === 0,
+], TableAction::class);
+```
+You can also simply set the `visibility` to a boolean instead of giving it a function:
+```php
+TableAction::OPT_VISIBILITY => false
+```
+
+### Options
+Take a look at the constants on the `Action` or the `TableAction` class.
+You can use all of these to further configure your action.
 
 ## Filters
 

--- a/src/Action/TableAction.php
+++ b/src/Action/TableAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace araise\TableBundle\Action;
+
+use araise\CoreBundle\Action\Action as BaseAction;
+
+class TableAction extends BaseAction
+{
+    public const OPT_VISIBILITY = 'visibility';
+
+    public function __construct(string $acronym, array $options)
+    {
+        $this->defaultOptions[self::OPT_VISIBILITY] = true;
+        $this->allowedTypes[self::OPT_VISIBILITY] = ['boolean', 'callable'];
+        parent::__construct($acronym, $options);
+    }
+
+    public function getVisibility(?object $entity = null): bool
+    {
+        if (is_callable($this->getOption(self::OPT_VISIBILITY))) {
+            return $this->getOption(self::OPT_VISIBILITY)($entity);
+        }
+
+        return $this->getOption(self::OPT_VISIBILITY);
+    }
+}

--- a/src/Resources/views/tailwind_2/_table.html.twig
+++ b/src/Resources/views/tailwind_2/_table.html.twig
@@ -206,38 +206,41 @@
                 {% if tableActions|length %}
                     <td class="whatwedo_table-actions pr-6 align-top">
 
-                        <div
-                            class="relative flex justify-end items-center" {{ stimulus_controller('araise/core-bundle/dropdown') }}>
-                            <button
-                                class="whatwedo_table-actions-button"
-                                {{ stimulus_action('araise/core-bundle/dropdown', 'toggle') |
-                                stimulus_action('araise/core-bundle/dropdown', 'close', 'scroll@window') |
-                                stimulus_action('araise/core-bundle/dropdown', 'layoutCalculate') |
-                                stimulus_action('araise/core-bundle/dropdown', 'layoutCalculate', 'resize@window') }}
-                                type="button"
-                            >
-                                <span class="sr-only">Optionen</span>
-                                {{ bootstrap_icon('three-dots-vertical', { class: 'h-4 w-4' }) }}
-                            </button>
-
+                        {% set tableActionsVisible = tableActions | filter(action => not attribute(action, 'visibility') is defined or action.visibility(row)) %}
+                        {% if tableActionsVisible|length %}
                             <div
-                                {{ stimulus_target('araise/core-bundle/dropdown', 'menu') }}
-                                class="z-50 hidden transition duration-300 origin-top-right mx-3 origin-top-right absolute right-7 top-0 -translate-x-1 w-48 -mt-1 rounded-md shadow-lg z-10 bg-white ring-1 ring-black ring-opacity-5 divide-y divide-neutral-200 focus:outline-none"
-                                data-transition-enter-from="opacity-0 scale-95"
-                                data-transition-enter-to="opacity-100 scale-100"
-                                data-transition-leave-from="opacity-100 scale-100"
-                                data-transition-leave-to="opacity-0 scale-95"
-                                tabindex="-1"
-                            >
-                                <div class="py-1" role="none">
-                                    {% for action in tableActions %}
-                                        <span class="block">
-                                            {{ araise_table_action_render(action, row) }}
-                                        </span>
-                                    {% endfor %}
+                                class="relative flex justify-end items-center" {{ stimulus_controller('araise/core-bundle/dropdown') }}>
+                                <button
+                                    class="whatwedo_table-actions-button"
+                                    {{ stimulus_action('araise/core-bundle/dropdown', 'toggle') |
+                                    stimulus_action('araise/core-bundle/dropdown', 'close', 'scroll@window') |
+                                    stimulus_action('araise/core-bundle/dropdown', 'layoutCalculate') |
+                                    stimulus_action('araise/core-bundle/dropdown', 'layoutCalculate', 'resize@window') }}
+                                    type="button"
+                                >
+                                    <span class="sr-only">Optionen</span>
+                                    {{ bootstrap_icon('three-dots-vertical', { class: 'h-4 w-4' }) }}
+                                </button>
+
+                                <div
+                                    {{ stimulus_target('araise/core-bundle/dropdown', 'menu') }}
+                                    class="z-50 hidden transition duration-300 origin-top-right mx-3 origin-top-right absolute right-7 top-0 -translate-x-1 w-48 -mt-1 rounded-md shadow-lg z-10 bg-white ring-1 ring-black ring-opacity-5 divide-y divide-neutral-200 focus:outline-none"
+                                    data-transition-enter-from="opacity-0 scale-95"
+                                    data-transition-enter-to="opacity-100 scale-100"
+                                    data-transition-leave-from="opacity-100 scale-100"
+                                    data-transition-leave-to="opacity-0 scale-95"
+                                    tabindex="-1"
+                                >
+                                    <div class="py-1" role="none">
+                                        {% for action in tableActionsVisible %}
+                                            <span class="block">
+                                                {{ araise_table_action_render(action, row) }}
+                                            </span>
+                                        {% endfor %}
+                                    </div>
                                 </div>
                             </div>
-                        </div>
+                        {% endif %}
                     </td>
                 {% endif %}
             </tr>

--- a/src/Resources/views/tailwind_2_layout.html.twig
+++ b/src/Resources/views/tailwind_2_layout.html.twig
@@ -96,6 +96,71 @@
     {% endif %}
 {% endblock %}
 
+{% block table_action %}
+    {# @var action \araise\CrudBundle\Action\TableAction #}
+    {% if not attribute(action, 'visibility') is defined or action.visibility(entity) %}
+        {% if action.hasConfirmation() %}
+            <div
+                {{ stimulus_controller('araise/core-bundle/dropdown') }}
+                class="relative block"
+            >
+                <button
+                    {{ action.option('attr')|map((value, attr) => "#{attr}=\"#{value}\"")|join(' ')|raw }}
+                    {{ stimulus_action('araise/core-bundle/dropdown', 'toggle') }}
+                    class="text-neutral-700 font-bold group flex items-center px-4 py-2 text-base" tabindex="-1"
+                >
+                    {% if action.option('icon') %}
+                        {{ bootstrap_icon(action.icon, { class: 'inline mr-3 h-5 w-5 text-neutral-400 group-hover:text-neutral-500' }) }}
+                    {% endif %}
+                    {{ action.label|trans }}
+                </button>
+                <div
+                    {{ stimulus_target('araise/core-bundle/dropdown', 'menu') }}
+                    class="z-50 hidden transition duration-300 transform origin-top-right absolute right-0 -bottom-3 transform translate-y-full bg-white shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5"
+                    data-transition-enter-from="opacity-0 scale-95"
+                    data-transition-enter-to="opacity-100 scale-100"
+                    data-transition-leave-from="opacity-100 scale-100"
+                    data-transition-leave-to="opacity-0 scale-95"
+                    tabindex="-1"
+                >
+                    <form
+                        class="flex items-center justify-between px-4 py-3"
+                        method="get" action="{{ path(action.route, action.routeParameters(entity)) }}">
+                        <p class="whatwedo-utility-bold whitespace-nowrap mr-4">
+                            {{ action.confirmation('label') | trans }}
+                        </p>
+
+                        <div class="flex space-x-2">
+                            <button class="whatwedo-crud-button--action-danger">
+                                {{ action.confirmation('yes') | trans }}
+                            </button>
+                            <button
+                                {{ stimulus_action('araise/core-bundle/dropdown', 'close') }}
+                                class="whatwedo-crud-button--action-no-bg"
+                                type="button"
+                            >
+                                {{ action.confirmation('no') | trans }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        {% else %}
+            <a
+                href="{{ path(action.route, action.routeParameters(entity)) }}"
+                class="whatwedo-utility-bold group flex items-center px-4 py-2 hover:bg-neutral-200 transition-colors"
+                tabindex="-1"
+                {{ action.option('attr')|map((value, attr) => "#{attr}=\"#{value}\"")|join(' ')|raw }}
+            >
+                {% if action.option('icon') %}
+                    {{ bootstrap_icon(action.icon, { class: 'inline mr-3 h-5 w-5 text-neutral-400 group-hover:text-neutral-500' }) }}
+                {% endif %}
+                {{ action.label|trans }}
+            </a>
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
 {% block post_action %}
     {% if action.hasConfirmation() %}
         <div


### PR DESCRIPTION
Allows the user to define custom TableActions with visibility like so:

```php
public function configureTableActions(Table $table): void
    {
        parent::configureTableActions($table);

        $table->addAction('test', [
            Action::OPT_LABEL => 'Test',
            Action::OPT_ROUTE => self::getRoute(Page::SHOW),
            Action::OPT_ROUTE_PARAMETERS => fn ($row) => [
                'id' => $row->getId(),
            ],
            TableAction::OPT_VISIBILITY => fn($row) => $row->getId() % 2 === 0,
        ], TableAction::class);
    }
```