### PR TITLE
feat(footer): allow adding footer to table

### DIFF
--- a/docs/table-configuration.md
+++ b/docs/table-configuration.md
@@ -74,6 +74,33 @@ All Options are as constants in `Column` class.
 - `formatter`: [Formatter](formatter.md)
 - `sort_expression`: String, example: `'trainerGroup.name'`
 
+## Footer Columns
+In this example we would like to add a count of the content at the end of our table.
+We can to this by adding a footer column like so:
+
+```php
+$data= [
+    [
+        'id' => 1,
+    ],
+    [
+        'id' => 2,
+    ]
+];
+
+$table
+    ->setFooterData(['count' => count($data)])
+    ->addFooterColumn('totalLabel', null, [
+        Column::OPT_CALLABLE => fn (array $content) => 'Total',
+    ])
+    ->addFooterColumn('count', null, [
+        Column::OPT_CALLABLE => fn(array $content) => $content['count'],
+    ])
+;
+```
+
+Note that this is only a simple example. The data could easily be replaced with an array of entities for example.
+
 ## Action Columns
 
 Action Columns are here to link to other pages (f.ex. link to edit or view).

--- a/src/Resources/views/tailwind_2/_table.html.twig
+++ b/src/Resources/views/tailwind_2/_table.html.twig
@@ -302,5 +302,26 @@
             {% endfor %}
         {% endfor %}
         </tbody>
+        {% block footer_columns %}
+            {% if table.footerColumns is not null %}
+                <tfoot class="whatwedo_table-foot whatwedo-utility-paragraph">
+                <tr class="whatwedo_table-row border-t border-neutral-300 bg-neutral-200 text-base font-medium text-neutral-600 text-left tracking-wide align-top">
+                    {% for footerColumn in table.footerColumns %}
+                        {% set attr = footerColumn.option('attributes')|default([])|filter((k,i) => k != 'class') %}
+                        <td
+                            class="px-3 py-2 {{ footerColumn.option('attributes')['class'] ?? '' }}"
+                            {{ attr|map((value, attr) => "#{attr}=\"#{value}\"")|join(' ')|raw }}
+                        >
+                            {{ araise_table_column_render(footerColumn, table.footerData) }}
+                        </td>
+                    {% endfor %}
+
+                    {% if table.actions|length %}
+                        <td class="px-3 py-2"></td>
+                    {% endif %}
+                </tr>
+                </tfoot>
+            {% endif %}
+        {% endblock %}
     </table>
 </div>

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -61,6 +61,10 @@ class Table
 
     protected array $columns = [];
 
+    protected ?array $footerColumns = null;
+
+    protected mixed $footerData = null;
+
     protected array $actions = [];
 
     protected array $batchActions = [];
@@ -205,33 +209,38 @@ class Table
         return $this->columns;
     }
 
+    /**
+     * @return Column[]
+     */
+    public function getFooterColumns(): ?array
+    {
+        if ($this->footerColumns === null) {
+            return null;
+        }
+        uasort($this->footerColumns, fn (Column $a, Column $b) => $b->getOption(Column::OPT_PRIORITY) <=> $a->getOption(Column::OPT_PRIORITY));
+
+        return $this->footerColumns;
+    }
+
     public function addColumn(string $acronym, $type = null, array $options = [], ?int $position = null): static
     {
-        if ($type === null) {
-            $type = Column::class;
-        }
-
-        if ($this->options[self::OPT_DEFINITION]) {
-            if (!isset($options[Column::OPT_LABEL])) {
-                $options[Column::OPT_LABEL] = sprintf('wwd.%s.property.%s', $this->options[self::OPT_DEFINITION]->getEntityAlias(), $acronym);
-            }
-        }
-
-        // set link_the_column_content on first column if not set
-        if (!isset($options[Column::OPT_LINK_THE_COLUMN_CONTENT]) && count($this->columns) === 0) {
-            $options[Column::OPT_LINK_THE_COLUMN_CONTENT] = true;
-        }
-
-        $column = new $type($this, $acronym, $options);
-
-        if ($column instanceof FormattableColumnInterface) {
-            $column->setFormatterManager($this->formatterManager);
-        }
-
+        $column = $this->internalAddColumn($acronym, $type, $options);
         if ($position === null) {
             $this->columns[$acronym] = $column;
         } else {
-            $this->insertColumnAtPosition($acronym, $column, $position);
+            $this->insertColumnAtPosition($this->columns, $acronym, $column, $position);
+        }
+
+        return $this;
+    }
+
+    public function addFooterColumn(string $acronym, $type = null, array $options = [], ?int $position = null): static
+    {
+        $column = $this->internalAddColumn($acronym, $type, $options, false);
+        if ($position === null) {
+            $this->footerColumns[$acronym] = $column;
+        } else {
+            $this->insertColumnAtPosition($this->footerColumns, $acronym, $column, $position);
         }
 
         return $this;
@@ -240,6 +249,13 @@ class Table
     public function removeColumn($acronym): static
     {
         unset($this->columns[$acronym]);
+
+        return $this;
+    }
+
+    public function removeFooterColumn($acronym): static
+    {
+        unset($this->footerColumns[$acronym]);
 
         return $this;
     }
@@ -367,6 +383,18 @@ class Table
         return $this->extensions[$extension]->setTable($this);
     }
 
+    public function getFooterData(): mixed
+    {
+        return $this->footerData;
+    }
+
+    public function setFooterData(mixed $footerData): static
+    {
+        $this->footerData = $footerData;
+
+        return $this;
+    }
+
     public function removeExtension(string $extension): void
     {
         unset($this->extensions[$extension]);
@@ -451,12 +479,12 @@ class Table
         $this->eventDispatcher->dispatch(new DataLoadEvent($this), DataLoadEvent::POST_LOAD);
     }
 
-    protected function insertColumnAtPosition($key, $value, $position)
+    protected function insertColumnAtPosition(&$columns, $key, $value, $position)
     {
         $newArray = [];
         $added = false;
         $i = 0;
-        foreach ($this->columns as $elementsAcronym => $elementsElement) {
+        foreach ($columns as $elementsAcronym => $elementsElement) {
             if ($position === $i) {
                 $newArray[$key] = $value;
                 $added = true;
@@ -467,7 +495,33 @@ class Table
         if (! $added) {
             $newArray[$key] = $value;
         }
-        $this->columns = $newArray;
+        $columns = $newArray;
+    }
+
+    private function internalAddColumn(string $acronym, $type = null, array $options = [], bool $mainColumns = true): Column
+    {
+        if ($type === null) {
+            $type = Column::class;
+        }
+
+        if ($this->options[self::OPT_DEFINITION] && $mainColumns) {
+            if (!isset($options[Column::OPT_LABEL])) {
+                $options[Column::OPT_LABEL] = sprintf('wwd.%s.property.%s', $this->options[self::OPT_DEFINITION]->getEntityAlias(), $acronym);
+            }
+        }
+
+        // set link_the_column_content on first column if not set
+        if (!isset($options[Column::OPT_LINK_THE_COLUMN_CONTENT]) && count($this->columns) === 0 && $mainColumns) {
+            $options[Column::OPT_LINK_THE_COLUMN_CONTENT] = true;
+        }
+
+        $column = new $type($this, $acronym, $options);
+
+        if ($column instanceof FormattableColumnInterface) {
+            $column->setFormatterManager($this->formatterManager);
+        }
+
+        return $column;
     }
 
     /**


### PR DESCRIPTION
allow to configure `footerColumns`. Usage would be something like following:

```php
        $dataloader = $table->getDataLoader();
        $order = null;
        if ($dataloader->getOption(DoctrineDataLoader::OPT_QUERY_BUILDER) instanceof QueryBuilder) {
            /** @var QueryBuilder $qb */
            $qb = $dataloader->getOption(DoctrineDataLoader::OPT_QUERY_BUILDER);
            foreach ($qb->getParameters() as $parameter) {
                if ($parameter->getValue() instanceof Order) {
                    $order = $parameter->getValue();
                    break;
                }
            }
        }
        if ($order) {
            $table
                ->setFooterData($order)
                ->addFooterColumn('1', null,  [
                    Column::OPT_CALLABLE => fn (Order $order) => '',
                    Column::OPT_ATTRIBUTES => [
                       'colspan' => 4,
                     ],
                 )
                ->addFooterColumn('itemCount')
                ->addFooterColumn('6', null, $emptyCallable)
                ->addFooterColumn('total', null, [
                    Column::OPT_FORMATTER => MoneyFormatter::class,
                    Column::OPT_FORMATTER_OPTIONS => [
                        MoneyFormatter::OPT_CURRENCY_POSITION => 'end',
                    ],
                ])
            ;
        }
```