### PR TITLE
fix: checkall batch action without pagination #35

### DIFF
--- a/src/Resources/views/tailwind_2/_pagination.html.twig
+++ b/src/Resources/views/tailwind_2/_pagination.html.twig
@@ -153,5 +153,11 @@
                 {% endif %}
             </div>
         </footer>
+    {% else %}
+        <footer class="whatwedo_table:footer w-full my-3 px-3 flex items-center justify-between">
+            <p class="whatwedo-utility-paragraph inline-block">
+                <span class="text-neutral-500 hidden" {{ stimulus_target('@araise/table-bundle/table_select', 'selectedCount') }}/>
+            </p>
+        </footer>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
Proposition to fix the issue #35 

There is also the possibility to change the stimulus controller to not show the amount of selected entries but it is always a nice feature to have.