### PR TITLE
feat: add sub_table_collapsed option to table

### DIFF
--- a/docs/table-configuration.md
+++ b/docs/table-configuration.md
@@ -22,6 +22,32 @@ All Options are as constants in `Table` class.
 - - `content_show_header`: Boolean, default: `true`
 - - `content_show_entry_dropdown`: Boolean, default: `true`
 - - `content_show_pagination_if_page_total_less_than_limit`: Boolean, default: `true`
+- `sub_table_collapsed`: Boolean or callable, default: `true`
+
+
+### Collapse Sub-Tables
+By default, sub-tables will be rendered collapsed. 
+This can be changed by setting the `sub_table_collapsed` option to either `false` or pass a callable that returns a boolean.
+
+```php
+$table->setOption(Table::OPT_SUB_TABLE_COLLAPSED, false);
+```
+
+Note that if you pass a function, you will get the current row as an argument.
+You can use this to only expand certain rows:
+
+```php
+// Expand only users with an email
+$table->setOption(Table::OPT_SUB_TABLE_COLLAPSED, function(array|object $row) {
+    if(!$row instanceof User) {
+        return true;
+    }
+    if($row->getEmail() !== null) {
+        return false;
+    }
+    return true;
+});
+```
 
 
 ## Column Options

--- a/src/Resources/assets/controllers/accordion_controller.js
+++ b/src/Resources/assets/controllers/accordion_controller.js
@@ -4,6 +4,40 @@ export default class extends Controller {
     static targets = ['header', 'content', 'arrow']
     static classes = ['arrowRotate', 'contentHidden']
 
+    initialize() {
+        super.initialize();
+
+        /** @type {HTMLElement[]} */
+        const contentTargets = this.contentTargets;
+
+        /** @type {HTMLElement[]} */
+        const headerTargets = this.headerTargets;
+
+        /** @type {string[]} */
+        const arrowRotateClasses = this.arrowRotateClasses;
+
+        /** @type {string[]} */
+        const contentHiddenClasses = this.contentHiddenClasses;
+
+        headerTargets.forEach((header) => {
+            const isOpen = header.getAttribute('aria-expanded') === 'true';
+            const content = header.nextElementSibling;
+            const arrow = this.closestChildTarget(header, 'arrow');
+
+            if(!arrow) {
+                return;
+            }
+
+            if (isOpen) {
+                arrow.classList.add(...arrowRotateClasses);
+                content.classList.remove(...contentHiddenClasses);
+            } else {
+                arrow.classList.remove(...arrowRotateClasses);
+                content.classList.add(...contentHiddenClasses);
+            }
+        });
+    }
+
     /**
      * @param {Event} event
      */
@@ -31,22 +65,15 @@ export default class extends Controller {
 
         const isOpen = header.getAttribute('aria-expanded') === 'true';
 
-        // Reset all accordions
-        headerTargets.forEach((header) => {
-            header.setAttribute('aria-expanded', 'false');
-        });
-        arrowTargets.forEach((arrow) => {
-            arrow.classList.remove(...arrowRotateClasses);
-        });
-        contentTargets.forEach((content) => {
-            content.classList.add(...contentHiddenClasses);
-        });
-
         // Open the current accordion if it wasn't open before (else we toggle it)
         if (!isOpen) {
             arrow.classList.add(...arrowRotateClasses);
             header.setAttribute('aria-expanded', 'true');
             content.classList.remove(...contentHiddenClasses);
+        } else {
+            arrow.classList.remove(...arrowRotateClasses);
+            header.setAttribute('aria-expanded', 'false');
+            content.classList.add(...contentHiddenClasses);
         }
     }
 
@@ -62,6 +89,20 @@ export default class extends Controller {
         }
 
         return element.parentElement;
+    }
+
+
+    /**
+     * @param {HTMLElement|null} element
+     * @param {string} target
+     */
+    closestChildTarget(element, target) {
+        const childElement = element.querySelector(`[data-araise--table-bundle--accordion-target='${target}']`);
+        if(childElement) {
+            return childElement;
+        }
+
+        return null;
     }
 }
 

--- a/src/Resources/views/tailwind_2/_table.html.twig
+++ b/src/Resources/views/tailwind_2/_table.html.twig
@@ -177,7 +177,7 @@
             <tr
                 class="whatwedo_table-row hover:bg-neutral-100 transition duration-500 color align-top"
                 {{ stimulus_target('araise/table-bundle/accordion', 'header') }}
-                aria-expanded="false"
+                aria-expanded="{{ table.getSubTableCollapsed(row) ? 'false' : 'true' }}"
             >
                 {% if table.hasBatchActions() and table.getOption('content_visibility')['content_show_header'] %}
                     <td class="px-6 py-2">

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -57,6 +57,8 @@ class Table
 
     public const OPT_SUB_TABLE_LOADER = 'sub_table_loader';
 
+    public const OPT_SUB_TABLE_COLLAPSED = 'sub_table_collapsed';
+
     protected array $columns = [];
 
     protected array $actions = [];
@@ -112,6 +114,7 @@ class Table
             self::OPT_DEFINITION => null,
             self::OPT_DATALOADER_OPTIONS => [],
             self::OPT_SUB_TABLE_LOADER => null,
+            self::OPT_SUB_TABLE_COLLAPSED => true,
         ]);
 
         $resolver->setAllowedTypes(self::OPT_TITLE, ['null', 'string']);
@@ -129,6 +132,7 @@ class Table
         $resolver->setAllowedTypes(self::OPT_SUB_TABLE_LOADER, ['null', 'callable']);
         $resolver->setRequired(self::OPT_DATA_LOADER);
         $resolver->setAllowedTypes(self::OPT_DATA_LOADER, allowedTypes: DataLoaderInterface::class);
+        $resolver->setAllowedTypes(self::OPT_SUB_TABLE_COLLAPSED, ['boolean', 'callable']);
     }
 
     public function getSubTables(object|array $row): array
@@ -166,6 +170,14 @@ class Table
     public function getPrimaryLink(object|array $row)
     {
         return is_callable($this->options[self::OPT_PRIMARY_LINK]) ? $this->options[self::OPT_PRIMARY_LINK]($row) : null;
+    }
+
+    public function getSubTableCollapsed(object|array $row): bool
+    {
+        if (is_callable($this->options[self::OPT_SUB_TABLE_COLLAPSED])) {
+            return $this->options[self::OPT_SUB_TABLE_COLLAPSED]($row);
+        }
+        return $this->options[self::OPT_SUB_TABLE_COLLAPSED];
     }
 
     public function setOption(string $key, $value): static


### PR DESCRIPTION
References: https://dev.whatwedo.ch/araise/araise-meta/-/issues/13

Create a way to configure if the subTables are collapsed or not by default.

You can set this by configuring the Table like this:
```php
$table->setOption(Table::OPT_SUB_TABLE_COLLAPSED, false);
```

Or by passing a callable:
```php
$table->setOption(Table::OPT_SUB_TABLE_COLLAPSED, function(array|object $row) {
    if($row->getId() === 1) {
        return false;
    }
    return true;
});
```